### PR TITLE
add functionality for local disk config policies

### DIFF
--- a/tests/unit_test/server/test_ut_server_localdisk.py
+++ b/tests/unit_test/server/test_ut_server_localdisk.py
@@ -1,0 +1,161 @@
+import pytest
+from ucsm_apis.server import localdisk
+from ucsmsdk.ucshandle import UcsHandle
+
+handle = UcsHandle("10.10.10.10", "username", "password")
+
+
+def test_localdisk_policy_create_success(mocker):
+    mock_login = mocker.patch('ucsmsdk.ucshandle.UcsHandle.login',
+                              autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch('ucsmsdk.ucshandle.UcsHandle.query_dn',
+                                 autospec=True)
+    mock_query_dn.return_value = "org-root"
+    mock_commit = mocker.patch('ucsmsdk.ucshandle.UcsHandle.commit',
+                               autospec=True)
+    mock_commit.return_value = None
+    mock_localdisk = mocker.patch('ucsm_apis.server.localdisk.StorageLocalDiskConfigPolicy')
+    mock_add_mo = mocker.patch('ucsmsdk.ucshandle.UcsHandle.add_mo',
+                               autospec=True)
+    mock_add_mo.return_value = None
+
+    localdisk.localdisk_policy_create(handle, name="dummypolicy")
+
+    mock_query_dn.assert_called_with(handle, "org-root")
+    mock_localdisk.assert_called_with(name='dummypolicy',
+                                      descr=None,
+                                      parent_mo_or_dn='org-root',
+                    flex_flash_raid_reporting_state="disable",
+                                      flex_flash_state="disable",
+                                      mode="any-configuration",
+                                      protect_config="no")
+
+
+def test_localdisk_policy_create_fail_org_not_exist(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = None
+
+    with pytest.raises(localdisk.UcsOperationError):
+        localdisk.localdisk_policy_create(handle, name="dummypolicy",
+                                          org_dn="dummy")
+
+
+def test_localdisk_policy_get_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = "org-root/local-disk-config-dummypolicy"
+
+    localdisk.localdisk_policy_get(handle, name="dummypolicy")
+
+    mock_query_dn.assert_called_with(handle, "org-root/local-disk-config-dummypolicy")
+
+
+def test_localdisk_policy_get_fail_policy_does_not_exist(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = None
+
+    with pytest.raises(localdisk.UcsOperationError):
+        localdisk.localdisk_policy_get(handle, name="nopool")
+
+
+def test_localdisk_policy_exists_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = "org-root/local-disk-config-dummypolicy"
+    mock_check_prop = mocker.patch.object(localdisk.StorageLocalDiskConfigPolicy,
+                                          'check_prop_match', autospec=True)
+    mock_check_prop.return_value = True
+    mock_get = mocker.patch.object(localdisk, 'localdisk_policy_get',
+                                   autospec=True)
+
+    localdisk.localdisk_policy_exists(handle, name="dummypolicy")
+
+    mock_get.assert_called_with(handle=handle, caller='localdisk_policy_exists',
+                                name="dummypolicy", org_dn="org-root")
+
+
+def test_localdisk_policy_exists_fail_org_does_not_exist(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(localdisk, 'localdisk_policy_get',
+                                   autospec=True)
+    mock_get.side_effect = localdisk.UcsOperationError("query_dn",
+                                                      "pool does not exist")
+
+    result = localdisk.localdisk_policy_exists(handle, name="dummypolicy")
+
+    assert result == (False, None)
+
+
+def test_localdisk_policy_modify_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(localdisk, 'localdisk_policy_get',
+                                   autospec=True)
+    mo_mock = mocker.Mock()
+    mo_mock.set_prop_multiple.return_value = True
+    mock_get.return_value = mo_mock
+    mock_set_mo = mocker.patch.object(UcsHandle, 'set_mo', autospec=True)
+    mock_set_mo.return_value = None
+    mock_commit = mocker.patch.object(UcsHandle, 'commit', autospec=True)
+    mock_commit.return_value = None
+
+    localdisk.localdisk_policy_modify(handle, name="dummypolicy",
+                                      descr="This is a new policy")
+
+    mock_get.assert_called_with(handle=handle, name="dummypolicy",
+                                org_dn="org-root", caller="localdisk_policy_modify")
+    mo_mock.set_prop_multiple.assert_called_with(descr="This is a new policy")
+
+
+def test_localdisk_policy_modify_failure_pool_nonexistent(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(localdisk, 'localdisk_policy_get',
+                                   autospec=True)
+    mock_get.side_effect = localdisk.UcsOperationError("query_dn",
+                                                      "pool does not exist")
+
+    with pytest.raises(localdisk.UcsOperationError):
+        localdisk.localdisk_policy_modify(handle, name="nopolicy",
+                                      descr="Policy no aqui")
+
+
+def test_localdisk_policy_delete_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(localdisk, 'localdisk_policy_get',
+                                   autospec=True)
+    mock_remove_mo = mocker.patch.object(UcsHandle, 'remove_mo',
+                                         autospec=True)
+    mock_commit = mocker.patch.object(UcsHandle, 'commit', autospec=True)
+    mock_commit.return_value = None
+
+    localdisk.localdisk_policy_delete(handle, "dummypolicy")
+
+    mock_get.assert_called_with(handle=handle, name="dummypolicy",
+                                org_dn="org-root", caller="localdisk_policy_delete")
+    assert mock_remove_mo.call_count == 1
+
+
+def test_localdisk_policy_delete_failure_pool_nonexistent(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(localdisk, 'localdisk_policy_get',
+                                   autospec=True)
+    mock_get.side_effect = localdisk.UcsOperationError("query_dn",
+                                                    "pool does not exist")
+
+    with pytest.raises(localdisk.UcsOperationError):
+        localdisk.localdisk_policy_delete(handle, name="dummypolicy")

--- a/ucsm_apis/server/localdisk.py
+++ b/ucsm_apis/server/localdisk.py
@@ -1,0 +1,208 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs operations related to mac pools.
+"""
+
+from ucsmsdk.mometa.storage.StorageLocalDiskConfigPolicy import (
+    StorageLocalDiskConfigPolicy)
+from ucsmsdk.ucsexception import UcsOperationError
+
+
+def localdisk_policy_create(handle, name=None,
+                            org_dn="org-root",
+                            descr=None,
+                            flex_flash_raid_reporting_state="disable",
+                            flex_flash_state="disable",
+                            mode="any-configuration",
+                            protect_config="no",
+                            **kwargs):
+
+    """
+    Creates local disk config policy
+
+    Args:
+        handle (UCSHandle)
+        name (string): Name of policy
+        org_dn (string): org dn
+        flex_flash_raid_reporting_state (string): Used if boot from SD
+                                                  ["disable", "enable"]
+        flex_flash_state (string): Used if boot from SD
+                                   ["disable", "enable"]
+        mode (string): RAID
+        protect_config (string): Preserve local disk config across
+                                 service profile disassociation.
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+
+    Returns:
+        StorageLocalDiskConfigPolicy: managed object
+
+    Raises:
+        UcsOperationError: if Org_dn is not present
+
+    Example:
+        localdisk_policy_create(handle,
+                                name="SD_Boot",
+                                descr="Boot from SD Cards",
+                                flex_flash_raid_reporting_state="enable",
+                                flex_flash_state="enable")
+    """
+
+    obj = handle.query_dn(org_dn)
+    if not obj:
+        raise UcsOperationError("localdisk_policy_create", "Org {} \
+                                 does not exist".format(org_dn))
+
+    mo = StorageLocalDiskConfigPolicy(parent_mo_or_dn=obj, name=name,
+                                      descr=descr,
+    flex_flash_raid_reporting_state=flex_flash_raid_reporting_state,
+                                      flex_flash_state=flex_flash_state,
+                                      mode=mode,
+                                      protect_config=protect_config)
+    mo.set_prop_multiple(**kwargs)
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def localdisk_policy_get(handle, name=None,
+                         org_dn="org-root",
+                         caller="localdisk_policy_get"):
+
+    """
+    Gets local disk config policy
+
+    Args:
+        handle (UCSHandle)
+        name (string): Name of policy
+        org_dn (string): org dn
+        caller (string): caller method name
+
+    Returns:
+        StorageLocalDiskConfigPolicy: managed object
+
+    Raises:
+        UcsOperationError: if StorageLocalDiskConfigPolicy is not present
+
+    Example:
+        localdisk_policy_get(handle,
+                             name="SD_Boot",
+                             org_dn="org-root")
+    """
+
+    dn = org_dn + "/local-disk-config-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise UcsOperationError(caller, "local disk policy {} \
+                                does not exist".format(dn))
+    return mo
+
+
+def localdisk_policy_exists(handle, name=None,
+                            org_dn="org-root", **kwargs):
+
+    """
+    checks if policy exists
+
+    Args:
+        handle (UcsHandle)
+        name (string): Name of local disk policy
+        org_dn (string): org dn
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucscoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, StorageLocalDiskConfigPolicy MO/None)
+
+    Raises:
+        None
+
+    Example:
+        localdisk_policy_exists:(handle,
+                                 name="SD_Boot",
+                                 org_dn="org-root")
+    """
+
+    try:
+        mo = localdisk_policy_get(handle=handle, name=name, org_dn=org_dn,
+                                  caller="localdisk_policy_exists")
+    except UcsOperationError:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def localdisk_policy_modify(handle, name=None,
+                            org_dn="org-root", **kwargs):
+
+    """
+    modifies policy
+
+    Args:
+        handle (UcsHandle)
+        name (string): Name of policy
+        org_dn (string): org dn
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucscoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        StorageLocalDiskConfigPolicy: managed object
+
+    Raises:
+        UcsOperationError: if StorageLocalDiskConfigPolicy is not present
+
+    Example:
+        localdisk_policy_modify(handle,
+                                name="SD_Boot",
+                                descr="prod local disk policy")
+    """
+
+    mo = localdisk_policy_get(handle=handle, name=name, org_dn=org_dn,
+                              caller="localdisk_policy_modify")
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def localdisk_policy_delete(handle, name=None, org_dn="org-root"):
+
+    """
+    deletes policy
+
+    Args:
+        handle (UcsHandle)
+        name (string): Name of policy
+        org_dn (string): org dn
+
+    Returns:
+        None
+
+    Raises:
+        UcsOperationError: if  is not present
+
+    Example:
+        mac_pool_delete(handle,
+                        name="test-pool",
+                        org_dn="org-root")
+    """
+
+    mo = localdisk_policy_get(handle=handle, name=name, org_dn=org_dn,
+                              caller="localdisk_policy_delete")
+    handle.remove_mo(mo)
+    handle.commit()


### PR DESCRIPTION
This module adds functionality for managing local disk config policies in UCS. All tests were written with pytest.