### PR TITLE
add functionality for bios policy

### DIFF
--- a/tests/unit_test/server/test_ut_server_bios.py
+++ b/tests/unit_test/server/test_ut_server_bios.py
@@ -1,0 +1,180 @@
+import pytest
+from ucsm_apis.server import bios
+from ucsmsdk.ucshandle import UcsHandle
+
+handle = UcsHandle("10.10.10.10", "username", "password")
+
+
+def test_bios_policy_create_success(mocker):
+    mock_login = mocker.patch('ucsmsdk.ucshandle.UcsHandle.login',
+                              autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch('ucsmsdk.ucshandle.UcsHandle.query_dn',
+                                 autospec=True)
+    mock_query_dn.return_value = "org-root"
+    mock_commit = mocker.patch('ucsmsdk.ucshandle.UcsHandle.commit',
+                               autospec=True)
+    mock_commit.return_value = None
+    mock_bios = mocker.patch('ucsm_apis.server.bios.BiosVProfile')
+    mock_cdn = mocker.patch('ucsm_apis.server.bios.BiosVfConsistentDeviceNameControl')
+    mock_fpl = mocker.patch('ucsm_apis.server.bios.BiosVfFrontPanelLockout')
+    mock_pep = mocker.patch('ucsm_apis.server.bios.BiosVfPOSTErrorPause')
+    mock_quiet = mocker.patch('ucsm_apis.server.bios.BiosVfQuietBoot')
+    mock_res = mocker.patch('ucsm_apis.server.bios.BiosVfResumeOnACPowerLoss')
+    mock_add_mo = mocker.patch('ucsmsdk.ucshandle.UcsHandle.add_mo',
+                               autospec=True)
+    mock_add_mo.return_value = None
+    mo1_mock = mocker.Mock()
+    mock_bios.return_value = mo1_mock
+
+    bios.bios_policy_create(handle, name="no_reboot")
+
+    mock_query_dn.assert_called_with(handle, "org-root")
+    mock_bios.assert_called_with(name="no_reboot",
+                                 parent_mo_or_dn="org-root",
+                                 descr=None,
+                                 reboot_on_update="no")
+    mock_cdn.assert_called_with(parent_mo_or_dn=mo1_mock,
+                                vp_cdn_control="platform-default")
+    mock_fpl.assert_called_with(parent_mo_or_dn=mo1_mock,
+                                vp_front_panel_lockout="platform-default")
+    mock_pep.assert_called_with(parent_mo_or_dn=mo1_mock,
+                                vp_post_error_pause="platform-default")
+    mock_quiet.assert_called_with(parent_mo_or_dn=mo1_mock,
+                                  vp_quiet_boot="disabled")
+    mock_res.assert_called_with(parent_mo_or_dn=mo1_mock,
+                                vp_resume_on_ac_power_loss="platform-default")
+
+
+
+def test_bios_policy_create_fail_org_not_exist(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = None
+
+    with pytest.raises(bios.UcsOperationError):
+        bios.bios_policy_create(handle, name="quiet_boot",
+                                        org_dn="dummy")
+
+
+def test_bios_policy_get_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = "org-root/bios-prof-quiet_boot"
+
+    bios.bios_policy_get(handle, name="quiet_boot")
+
+    mock_query_dn.assert_called_with(handle, "org-root/bios-prof-"
+                                     "quiet_boot")
+
+
+def test_bios_policy_get_fail_policy_does_not_exist(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = None
+
+    with pytest.raises(bios.UcsOperationError):
+        bios.bios_policy_get(handle, "nopolicy")
+
+
+def test_bios_policy_exists_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = "org-root/bios-prof-quiet_boot"
+    mock_check_prop = mocker.patch.object(bios.BiosVProfile,
+                                          'check_prop_match', autospec=True)
+    mock_check_prop.return_value = True
+    mock_get = mocker.patch.object(bios, 'bios_policy_get',
+                                   autospec=True)
+
+    bios.bios_policy_exists(handle, name="quiet_boot")
+
+    mock_get.assert_called_with(handle=handle,
+                                caller='bios_policy_exists',
+                                name="quiet_boot", org_dn="org-root")
+
+
+def test_bios_policy_exists_fail_org_does_not_exist(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(bios, 'bios_policy_get',
+                                   autospec=True)
+    mock_get.side_effect = bios.UcsOperationError("query_dn",
+                                                       "policy does not exist")
+
+    result = bios.bios_policy_exists(handle, name="no_policy")
+
+    assert result == (False, None)
+
+
+def test_bios_policy_modify_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(bios, 'bios_policy_get',
+                                   autospec=True)
+    mo_mock = mocker.Mock()
+    mo_mock.set_prop_multiple.return_value = True
+    mock_get.return_value = mo_mock
+    mock_set_mo = mocker.patch.object(UcsHandle, 'set_mo', autospec=True)
+    mock_set_mo.return_value = None
+    mock_commit = mocker.patch.object(UcsHandle, 'commit', autospec=True)
+    mock_commit.return_value = None
+
+    bios.bios_policy_modify(handle, name="quiet_boot",
+                                      descr="This is a new policy")
+
+    mock_get.assert_called_with(handle=handle, name="quiet_boot",
+                                org_dn="org-root",
+                                caller="bios_policy_modify")
+    mo_mock.set_prop_multiple.assert_called_with(descr="This is a new policy")
+
+
+def test_bios_policy_modify_failure_pool_nonexistent(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(bios, 'bios_policy_get',
+                                   autospec=True)
+    mock_get.side_effect = bios.UcsOperationError("query_dn",
+                                                  "policy does not exist")
+
+    with pytest.raises(bios.UcsOperationError):
+        bios.bios_policy_modify(handle, name="nopolicy",
+                                descr="Policy no aqui")
+
+
+def test_bios_policy_delete_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(bios, 'bios_policy_get',
+                                   autospec=True)
+    mock_remove_mo = mocker.patch.object(UcsHandle, 'remove_mo',
+                                         autospec=True)
+    mock_commit = mocker.patch.object(UcsHandle, 'commit', autospec=True)
+    mock_commit.return_value = None
+
+    bios.bios_policy_delete(handle, "quiet_boot")
+
+    mock_get.assert_called_with(handle=handle, name="quiet_boot",
+                                org_dn="org-root",
+                                caller="bios_policy_delete")
+    assert mock_remove_mo.call_count == 1
+
+
+def test_bios_policy_delete_failure_pool_nonexistent(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(bios, 'bios_policy_get',
+                                   autospec=True)
+    mock_get.side_effect = bios.UcsOperationError("query_dn",
+                                                  "policy does not exist")
+
+    with pytest.raises(bios.UcsOperationError):
+        bios.bios_policy_delete(handle, "quiet_boot")

--- a/ucsm_apis/server/bios.py
+++ b/ucsm_apis/server/bios.py
@@ -1,0 +1,224 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs operations related to network control policies.
+"""
+
+from ucsmsdk.mometa.bios.BiosVProfile import BiosVProfile
+from ucsmsdk.mometa.bios.BiosVfConsistentDeviceNameControl import BiosVfConsistentDeviceNameControl
+from ucsmsdk.mometa.bios.BiosVfFrontPanelLockout import BiosVfFrontPanelLockout
+from ucsmsdk.mometa.bios.BiosVfPOSTErrorPause import BiosVfPOSTErrorPause
+from ucsmsdk.mometa.bios.BiosVfQuietBoot import BiosVfQuietBoot
+from ucsmsdk.mometa.bios.BiosVfResumeOnACPowerLoss import BiosVfResumeOnACPowerLoss
+from ucsmsdk.ucsexception import UcsOperationError
+
+
+def bios_policy_create(handle, name=None,
+                       org_dn="org-root",
+                       reboot="no",
+                       descr=None,
+                       cdn_ctrl="platform-default",
+                       front_panel_lock="platform-default",
+                       post_err_pause="platform-default",
+                       quiet_boot="platform-default",
+                       res_power_loss="platform-default",
+                       **kwargs):
+
+    """
+    Creates bios policy
+
+    Args:
+        handle (UCSHandle)
+        name (string): Name of policy
+        org_dn (string): org dn
+        descr (string): description
+        reboot (string): Reboot on Update ["no", "yes]
+        cdn_ctrl (string): Consistent Device Name Control 
+                           ["enabled", "disabled", "platform-default",
+                            "platform-recommended"]
+        front_panel_lock (string): receive lldp 
+                                   ["enabled", "disabled", "platform-default",
+                                    "platform-recommended"]
+        post_err_pause (string): Post Error Pause
+                                 ["enabled", "disabled", "platform-default",
+                                  "platform-recommended"]
+        quiet_boot (string): Quiet Boot
+                             ["enabled", "disabled", "platform-default",
+                              "platform-recommended"]
+        res_power_loss (string): Resume after AC Power Loss 
+                                 ["enabled", "disabled", "platform-default",
+                                  "platform-recommended"]
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+
+    Returns:
+        BiosVProfile: managed object
+
+    Raises:
+        UcsOperationError: if Org_dn is not present
+
+    Example:
+        bios_policy_create(handle,
+                             name="no_quiet",
+                             descr="no quiet boot",
+                             quiet_boot="disabled")
+    """
+
+    obj = handle.query_dn(org_dn)
+    if not obj:
+        raise UcsOperationError("bios_policy_create", "Org {} \
+                                 does not exist".format(org_dn))
+
+    mo = BiosVProfile(parent_mo_or_dn=org_dn, name=name,
+                      descr=descr, reboot_on_update=reboot)
+    mo_1 = BiosVfConsistentDeviceNameControl(parent_mo_or_dn=mo, vp_cdn_control="platform-default")
+    mo_2 = BiosVfFrontPanelLockout(parent_mo_or_dn=mo, vp_front_panel_lockout="platform-default")
+    mo_3 = BiosVfPOSTErrorPause(parent_mo_or_dn=mo, vp_post_error_pause="platform-default")
+    mo_4 = BiosVfQuietBoot(parent_mo_or_dn=mo, vp_quiet_boot="disabled")
+    mo_5 = BiosVfResumeOnACPowerLoss(parent_mo_or_dn=mo, vp_resume_on_ac_power_loss="platform-default")
+    mo.set_prop_multiple(**kwargs)
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def bios_policy_get(handle, name=None,
+                      org_dn="org-root",
+                      caller="bios_policy_get"):
+
+    """
+    Gets bios policy
+
+    Args:
+        handle (UCSHandle)
+        name (string): Name of policy
+        org_dn (string): org dn
+        caller (string): caller method name
+
+    Returns:
+        BiosVProfile: managed object
+
+    Raises:
+        UcsOperationError: if BiosVProfile is not present
+
+    Example:
+        bios_policy_get(handle,
+                        name="quiet_boot",
+                        org_dn="org-root")
+    """
+
+    dn = org_dn + "/bios-prof-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise UcsOperationError(caller, "bios policy {} \
+                                does not exist".format(dn))
+    return mo
+
+
+def bios_policy_exists(handle, name=None,
+                       org_dn="org-root", **kwargs):
+
+    """
+    checks if policy exists
+
+    Args:
+        handle (UcsHandle)
+        name (string): Name of bios policy
+        org_dn (string): org dn
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucscoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, BiosVProfile MO/None)
+
+    Raises:
+        None
+
+    Example:
+        bios_policy_exists:(handle,
+                            name="quiet_boot",
+                            org_dn="org-root")
+    """
+
+    try:
+        mo = bios_policy_get(handle=handle, name=name, org_dn=org_dn,
+                             caller="bios_policy_exists")
+    except UcsOperationError:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def bios_policy_modify(handle, name=None,
+                       org_dn="org-root", **kwargs):
+
+    """
+    modifies policy
+
+    Args:
+        handle (UcsHandle)
+        name (string): Name of policy
+        org_dn (string): org dn
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucscoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        BiosVProfile: managed object
+
+    Raises:
+        UcsOperationError: if BiosVProfile is not present
+
+    Example:
+        bios_policy_modify(handle,
+                           name="quiet_boot",
+                           descr="prod bios policy")
+    """
+
+    mo = bios_policy_get(handle=handle, name=name, org_dn=org_dn,
+                         caller="bios_policy_modify")
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def bios_policy_delete(handle, name=None, org_dn="org-root"):
+
+    """
+    deletes policy
+
+    Args:
+        handle (UcsHandle)
+        name (string): Name of policy
+        org_dn (string): org dn
+
+    Returns:
+        None
+
+    Raises:
+        UcsOperationError: if  is not present
+
+    Example:
+        bios_policy_delete(handle,
+                           name="quiet_boot",
+                           org_dn="org-root")
+    """
+
+    mo = bios_policy_get(handle=handle, name=name, org_dn=org_dn,
+                           caller="bios_policy_delete")
+    handle.remove_mo(mo)
+    handle.commit()


### PR DESCRIPTION
This module adds functionality for managing bios policies in UCSM. All tests were written with pytest.